### PR TITLE
scripts to dockerize CI-BOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.12.1-alpine3.9 AS builder
+
+COPY . /go/src/github.com/Huawei-PaaS/ci-bot
+
+RUN apk --no-cache update && \
+apk --no-cache upgrade && \
+CGO_ENABLED=1 go build -v -o /usr/local/bin/ci-bot -ldflags="-w -s -extldflags -static" \
+github.com/Huawei-PaaS/ci-bot
+
+ENTRYPOINT ["ci-bot"]
+

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,13 @@ all:build
 
 build:ci-bot
 
+build-image:ci-bot-image
+
 ci-bot:
 	go build
+
+ci-bot-image:
+	docker build -t cibot:latest ./	
+
 clean:
 	rm -rf ./ci-bot

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,19 @@ Which issue(s) this PR fixes:
 Special notes for your reviewer:
 ***
 ```
+### Steps to build Dockerized ci-bot
+make build-image will build a dockerized ci-bot image
+
+```
+ make build-image
+     
+```
+### Steps to run Dockerized ci-bot
+Below command will run the Ci-Bot as conatiner
+
+```
+docker run -d -p 3000:3000 --name ci-bot --restart always --cpu-period=50000 --cpu-quota=100000 --memory=1g --privileged  cibot:latest --repo=https://github.com/repo/kubeedge.git --repoName=repo%2Fkubeedge --github-token=<github token> --travis-ci-token=<travis-ci-token> --webhook-secret=<webhook-secret>
+```
 #### Retest 
 retest is used to retest the PullRequest build
 


### PR DESCRIPTION
This scripts will dockerize CI-bot to run as containers

ci-bot running as a container
![Screenshot from 2019-04-04 20-11-00](https://user-images.githubusercontent.com/39593583/55566730-edfb9e80-5719-11e9-9715-94b51185d422.png)

Basic commands /assign and /unassign tested
![Screenshot from 2019-04-04 20-10-04](https://user-images.githubusercontent.com/39593583/55566779-07044f80-571a-11e9-90ec-b082b6315d1e.png)

**Issue**
#20 

